### PR TITLE
1.0.5: Added document level annotation capability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.hucompute.textimager.uima</groupId>
     <artifactId>biofid-agreement</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -17,12 +17,12 @@
             <version>855d573a4d</version>
             <exclusions>
                 <exclusion>
-                    <artifactId>typesystem</artifactId>
                     <groupId>org.texttechnologylab.annotation</groupId>
+                    <artifactId>typesystem</artifactId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>guava</artifactId>
                     <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -67,12 +67,6 @@
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
             <version>1.4</version>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>5.5.0-M1</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -133,11 +127,11 @@
         <dependency>
             <groupId>com.github.texttechnologylab</groupId>
             <artifactId>Utilities</artifactId>
-            <version>-SNAPSHOT</version>
+            <version>1.0.4</version>
             <exclusions>
                 <exclusion>
-                    <artifactId>guava</artifactId>
                     <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/src/main/java/org/biofid/agreement/engine/CodingAgreementAnnotatorEngine.java
+++ b/src/main/java/org/biofid/agreement/engine/CodingAgreementAnnotatorEngine.java
@@ -17,8 +17,8 @@ import org.dkpro.statistics.agreement.coding.PercentageAgreement;
  * <p/>
  * Convenience class for separate CAS annotation with empty {@link org.apache.uima.analysis_engine.AnalysisEngine#collectionProcessComplete collectionProcessComplete()}.
  * <br>
- * {@link AgreementAnnotatorEngine#PARAM_MULTI_CAS_HANDLING PARAM_MULTI_CAS_HANDLING} is fixed to {@link AgreementAnnotatorEngine#SEPARATE SEPARATE} and
- * {@link AgreementAnnotatorEngine#PARAM_ANNOTATE PARAM_ANNOTATE} is fixed to 'true'.
+ * {@link CodingAgreementAnnotatorEngine#PARAM_MULTI_CAS_HANDLING PARAM_MULTI_CAS_HANDLING} is fixed to {@link CodingAgreementAnnotatorEngine#SEPARATE SEPARATE} and
+ * {@link CodingAgreementAnnotatorEngine#PARAM_ANNOTATE_TOKEN PARAM_ANNOTATE} is fixed to 'true'.
  * <p/>
  * <b>IMPORTANT:</b>
  * Requires chosen agreement measure to implement interface {@link ICodingItemSpecificAgreement}!
@@ -37,13 +37,14 @@ import org.dkpro.statistics.agreement.coding.PercentageAgreement;
 @Parameters(
 		exclude = {
 				CodingIAACollectionProcessingEngine.PARAM_MULTI_CAS_HANDLING,
-				CodingIAACollectionProcessingEngine.PARAM_ANNOTATE
+				CodingIAACollectionProcessingEngine.PARAM_ANNOTATE_TOKEN
 		})
-public class AgreementAnnotatorEngine extends CodingIAACollectionProcessingEngine {
+public class CodingAgreementAnnotatorEngine extends CodingIAACollectionProcessingEngine {
 	@Override
 	public void initialize(UimaContext context) throws ResourceInitializationException {
 		super.initialize(context);
-		pAnnotate = true;
+		pAnnotateToken = true;
+		pAnnotateDocument = true;
 		pMultiCasHandling = SEPARATE;
 		if (!(ImmutableSet.of(KrippendorffAlphaAgreement, PercentageAgreement).contains(pAgreementMeasure))) {
 			throw new ResourceInitializationException(new UnsupportedOperationException(

--- a/src/main/java/org/biofid/agreement/engine/UnitizingAgreementAnnotatorEngine.java
+++ b/src/main/java/org/biofid/agreement/engine/UnitizingAgreementAnnotatorEngine.java
@@ -1,0 +1,41 @@
+package org.biofid.agreement.engine;
+
+import eu.openminted.share.annotations.api.Parameters;
+import org.apache.uima.UimaContext;
+import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
+import org.apache.uima.resource.ResourceInitializationException;
+import org.dkpro.statistics.agreement.ICategorySpecificAgreement;
+import org.dkpro.statistics.agreement.unitizing.KrippendorffAlphaUnitizingAgreement;
+
+/**
+ * Inter-annotator agreement engine using a {@link org.dkpro.statistics.agreement.unitizing.UnitizingAnnotationStudy UnitizingAnnotationStudy} and
+ * {@link org.dkpro.statistics.agreement.unitizing.KrippendorffAlphaUnitizingAgreement KrippendorffAlphaUnitizingAgreement} measure.
+ * <p/>
+ * Convenience class for separate CAS annotation with empty {@link org.apache.uima.analysis_engine.AnalysisEngine#collectionProcessComplete collectionProcessComplete()}.
+ * <br>
+ * {@link UnitizingAgreementAnnotatorEngine#PARAM_MULTI_CAS_HANDLING PARAM_MULTI_CAS_HANDLING} is fixed to {@link UnitizingAgreementAnnotatorEngine#SEPARATE SEPARATE} and
+ * {@link UnitizingAgreementAnnotatorEngine#PARAM_ANNOTATE_DOCUMENT PARAM_ANNOTATE} is fixed to 'true'.
+ * <p/>
+ *
+ * @see ICategorySpecificAgreement
+ * @see KrippendorffAlphaUnitizingAgreement
+ */
+
+@Parameters(
+		exclude = {
+				UnitizingIAACollectionProcessingEngine.PARAM_MULTI_CAS_HANDLING,
+				UnitizingIAACollectionProcessingEngine.PARAM_ANNOTATE_DOCUMENT
+		})
+public class UnitizingAgreementAnnotatorEngine extends UnitizingIAACollectionProcessingEngine {
+	@Override
+	public void initialize(UimaContext context) throws ResourceInitializationException {
+		super.initialize(context);
+		pAnnotateDocument = true;
+		pMultiCasHandling = SEPARATE;
+	}
+	
+	@Override
+	public void collectionProcessComplete() throws AnalysisEngineProcessException {
+		// Empty
+	}
+}

--- a/src/main/java/org/biofid/agreement/engine/UnitizingIAACollectionProcessingEngine.java
+++ b/src/main/java/org/biofid/agreement/engine/UnitizingIAACollectionProcessingEngine.java
@@ -168,6 +168,9 @@ public class UnitizingIAACollectionProcessingEngine extends AbstractIAAEngine {
 	}
 	
 	private void handleSeparate(JCas jCas, UnitizingAnnotationStudy completeStudy) {
+		if (!pPrintStatistics && ! pAnnotateDocument)
+			return;
+		
 		// Iterate over all previously collected studies
 		CountMap<String> categoryCount = new CountMap<>();
 		HashMap<String, CountMap<String>> annotatorCategoryCount = new HashMap<>();
@@ -186,6 +189,8 @@ public class UnitizingIAACollectionProcessingEngine extends AbstractIAAEngine {
 			annotatorCategoryCount.get(annotatorIndex.getKey(id)).inc(category);
 		}
 		
+		KrippendorffAlphaUnitizingAgreement agreement = new KrippendorffAlphaUnitizingAgreement(completeStudy);
+		
 		if (pPrintStatistics) {
 			try {
 				String documentId = DocumentMetaData.get(jCas).getDocumentId();
@@ -201,7 +206,6 @@ public class UnitizingIAACollectionProcessingEngine extends AbstractIAAEngine {
 						annotatorIndex.size(), annotatorIndex.keySet().toString()
 				));
 				
-				KrippendorffAlphaUnitizingAgreement agreement = new KrippendorffAlphaUnitizingAgreement(completeStudy);
 				// Print the agreement for all categories
 				csvPrinter.printRecord("Category", "Count", "Agreement");
 				csvPrinter.printRecord("Overall", completeStudy.getUnitCount(), agreement.calculateAgreement());
@@ -210,6 +214,11 @@ public class UnitizingIAACollectionProcessingEngine extends AbstractIAAEngine {
 			} catch (IOException e) {
 				e.printStackTrace();
 			}
+		}
+		
+		if (pAnnotateDocument) {
+			JCas viewIAA = initializeIaaView(jCas);
+			createDocumentAgreementAnnotations(viewIAA, agreement, "KrippendorffAlphaUnitizingAgreement", categories, categoryCount);
 		}
 	}
 	

--- a/src/test/java/org/biofid/agreement/engine/AgreementAnnotatorTest.java
+++ b/src/test/java/org/biofid/agreement/engine/AgreementAnnotatorTest.java
@@ -12,7 +12,7 @@ import org.apache.uima.jcas.cas.DoubleArray;
 import org.apache.uima.jcas.cas.LongArray;
 import org.apache.uima.jcas.cas.StringArray;
 import org.apache.uima.util.CasIOUtils;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.texttechnologylab.annotation.AbstractNamedEntity;
 import org.texttechnologylab.annotation.NamedEntity;
 import org.texttechnologylab.iaa.Agreement;
@@ -33,46 +33,50 @@ public class AgreementAnnotatorTest {
 			String xmiPath = "src/test/out/xmi/";
 			
 			JCas jCas = JCasFactory.createJCas();
+			
+			// Test parameters
+			boolean filterFingerprinted = false;
+			String[] annotationClasses = {NamedEntity.class.getName(), AbstractNamedEntity.class.getName()};
+			
+			AnalysisEngine codingAnnotatorEngine = AnalysisEngineFactory.createEngine(
+					CodingAgreementAnnotatorEngine.class,
+					CodingAgreementAnnotatorEngine.PARAM_ANNOTATION_CLASSES, annotationClasses,
+					CodingAgreementAnnotatorEngine.PARAM_MIN_VIEWS, 2,
+//						AgreementAnnotatorEngine.PARAM_ANNOTATOR_LIST, annotatorWhitelist,
+//						AgreementAnnotatorEngine.PARAM_ANNOTATOR_RELATION, AgreementAnnotatorEngine.WHITELIST,
+					CodingAgreementAnnotatorEngine.PARAM_ANNOTATOR_LIST, annotatorBlacklist,
+					CodingAgreementAnnotatorEngine.PARAM_ANNOTATOR_RELATION, CodingAgreementAnnotatorEngine.BLACKLIST,
+					CodingAgreementAnnotatorEngine.PARAM_FILTER_FINGERPRINTED, filterFingerprinted,
+					CodingAgreementAnnotatorEngine.PARAM_AGREEMENT_MEASURE, CodingAgreementAnnotatorEngine.KrippendorffAlphaAgreement,
+					CodingAgreementAnnotatorEngine.PARAM_SET_SELECTION_STRATEGY, SetSelectionStrategy.MAX,
+					CodingAgreementAnnotatorEngine.PARAM_PRINT_STATS, false
+			);
+			
+			AnalysisEngine unitizingAnnotatorEngine = AnalysisEngineFactory.createEngine(
+					UnitizingAgreementAnnotatorEngine.class,
+					UnitizingAgreementAnnotatorEngine.PARAM_ANNOTATION_CLASSES, annotationClasses,
+					UnitizingAgreementAnnotatorEngine.PARAM_MIN_VIEWS, 2,
+//						UnitizingAgreementAnnotatorEngine.PARAM_ANNOTATOR_LIST, annotatorWhitelist,
+//						UnitizingAgreementAnnotatorEngine.PARAM_ANNOTATOR_RELATION, AgreementAnnotatorEngine.WHITELIST,
+					UnitizingAgreementAnnotatorEngine.PARAM_ANNOTATOR_LIST, annotatorBlacklist,
+					UnitizingAgreementAnnotatorEngine.PARAM_ANNOTATOR_RELATION, CodingAgreementAnnotatorEngine.BLACKLIST,
+					UnitizingAgreementAnnotatorEngine.PARAM_FILTER_FINGERPRINTED, filterFingerprinted,
+					UnitizingAgreementAnnotatorEngine.PARAM_PRINT_STATS, false
+			);
 			try (FileInputStream inputStream = FileUtils.openInputStream(new File(xmiPath + "3713524.xmi"))) {
 				CasIOUtils.load(inputStream, null, jCas.getCas(), true);
 				
-				
-				// Test parameters
-				boolean filterFingerprinted = false;
-				String[] annotationClasses = {NamedEntity.class.getName(), AbstractNamedEntity.class.getName()};
-				
-				AnalysisEngine annotatorEngine = AnalysisEngineFactory.createEngine(
-						AgreementAnnotatorEngine.class,
-						AgreementAnnotatorEngine.PARAM_ANNOTATION_CLASSES, annotationClasses,
-						AgreementAnnotatorEngine.PARAM_MIN_VIEWS, 2,
-//						AgreementAnnotatorEngine.PARAM_ANNOTATOR_LIST, annotatorWhitelist,
-//						AgreementAnnotatorEngine.PARAM_ANNOTATOR_RELATION, AgreementAnnotatorEngine.WHITELIST,
-						AgreementAnnotatorEngine.PARAM_ANNOTATOR_LIST, annotatorBlacklist,
-						AgreementAnnotatorEngine.PARAM_ANNOTATOR_RELATION, AgreementAnnotatorEngine.BLACKLIST,
-						AgreementAnnotatorEngine.PARAM_FILTER_FINGERPRINTED, filterFingerprinted,
-						AgreementAnnotatorEngine.PARAM_AGREEMENT_MEASURE, AgreementAnnotatorEngine.KrippendorffAlphaAgreement,
-						AgreementAnnotatorEngine.PARAM_SET_SELECTION_STRATEGY, SetSelectionStrategy.MAX,
-						AgreementAnnotatorEngine.PARAM_PRINT_STATS, false
-				);
-				
-				SimplePipeline.runPipeline(jCas, annotatorEngine);
+				System.out.println("UnitizingAgreementAnnotatorEngine");
+				SimplePipeline.runPipeline(jCas, unitizingAnnotatorEngine);
 				
 				JCas iaa = jCas.getView("IAA");
+				printCategoryAgreement(iaa);
 				
-				AgreementContainer agreementContainer = Lists.newArrayList(JCasUtil.select(iaa, AgreementContainer.class)).get(0);
-				StringArray categoryNames = agreementContainer.getCategoryNames();
-				DoubleArray categoryAgreementValues = agreementContainer.getCategoryAgreementValues();
-				LongArray categoryCounts = agreementContainer.getCategoryCounts();
+				System.out.println("CodingAgreementAnnotatorEngine");
+				SimplePipeline.runPipeline(jCas, codingAnnotatorEngine);
 				
-				System.out.println("Category\tAgreement");
-				System.out.printf("Overall\t%f\n", agreementContainer.getOverallAgreementValue());
-				for (int i = 0; i < categoryNames.size(); i++) {
-					String category = categoryNames.get(i);
-					Double value = categoryAgreementValues.get(i);
-					Long count = categoryCounts.get(i);
-					System.out.printf("%s\t%d\t%f\n", category, count, value);
-				}
-				System.out.println();
+				iaa = jCas.getView("IAA");
+				printCategoryAgreement(iaa);
 				
 				System.out.println("Token\tAgreement");
 				Lists.newArrayList(JCasUtil.select(iaa, Agreement.class)).subList(0, 100)
@@ -83,5 +87,23 @@ public class AgreementAnnotatorTest {
 			e.printStackTrace();
 		}
 		System.out.println("\nDone");
+	}
+	
+	private void printCategoryAgreement(JCas iaa) {
+		AgreementContainer agreementContainer = Lists.newArrayList(JCasUtil.select(iaa, AgreementContainer.class)).get(0);
+		StringArray categoryNames = agreementContainer.getCategoryNames();
+		DoubleArray categoryAgreementValues = agreementContainer.getCategoryAgreementValues();
+		LongArray categoryCounts = agreementContainer.getCategoryCounts();
+		
+		
+		System.out.println("Category\tAgreement");
+		System.out.printf("Overall\t%f\n", agreementContainer.getOverallAgreementValue());
+		for (int i = 0; i < categoryNames.size(); i++) {
+			String category = categoryNames.get(i);
+			Double value = categoryAgreementValues.get(i);
+			Long count = categoryCounts.get(i);
+			System.out.printf("%s\t%d\t%f\n", category, count, value);
+		}
+		System.out.println();
 	}
 }

--- a/src/test/java/org/biofid/agreement/engine/InterAnnotatorAgreementEngineTest.java
+++ b/src/test/java/org/biofid/agreement/engine/InterAnnotatorAgreementEngineTest.java
@@ -7,7 +7,7 @@ import org.apache.uima.fit.factory.AggregateBuilder;
 import org.apache.uima.fit.factory.AnalysisEngineFactory;
 import org.apache.uima.fit.factory.CollectionReaderFactory;
 import org.apache.uima.fit.pipeline.SimplePipeline;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.texttechnologylab.annotation.AbstractNamedEntity;
 import org.texttechnologylab.annotation.NamedEntity;
 import org.texttechnologylab.utilities.uima.reader.TextAnnotatorRepositoryCollectionReader;


### PR DESCRIPTION
- All engines (coding & unitizing) can now create AgreementContainer annotations in the separate IAA view
- Added UnitizingAgreementAnnotatorEngine and renamed AgreementAnnotatorEngine to CodingAgreementAnnotatorEngine
- Renamed PARAM_ANNOTATE to PARAM_ANNOTATE_TOKEN in coding engines
- Added PARAM_ANNOTATE_DOCUMENT to AbstractIAAEngine
- Extended tests accordingly
- Downgraded JUnit to version 4 for maven compatibility