### PR TITLE
Version 1.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>org.texttechnologylab</groupId>
     <artifactId>textimager-uima-agreement</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/org/hucompute/textimager/uima/agreement/engine/relational/RelationAnnotationAgreement.java
+++ b/src/main/java/org/hucompute/textimager/uima/agreement/engine/relational/RelationAnnotationAgreement.java
@@ -71,6 +71,13 @@ public class RelationAnnotationAgreement extends AbstractIAAEngine {
     public void initialize(UimaContext context) throws ResourceInitializationException {
         annotationClasses = ImmutableSet.of(Entity.class, Event.class, Signal.class);
         super.initialize(context);
+        switch (pMultiCasHandling) {
+            case COMBINED:
+            case BOTH:
+                logger.warn(String.format("RelationAnnotationAgreement.PARAM_MULTI_CAS_HANDLING=%s is not implemented, " +
+                        "defaulting to SEPARATE.", pMultiCasHandling));
+                break;
+        }
     }
 
     @Override
@@ -189,7 +196,9 @@ public class RelationAnnotationAgreement extends AbstractIAAEngine {
 
             switch (pMultiCasHandling) {
                 case SEPARATE:
+                case COMBINED:
                 case BOTH:
+                default:
                     handleSeparate(
                             jCas,
                             predicateIdentificationStudy,
@@ -207,6 +216,15 @@ public class RelationAnnotationAgreement extends AbstractIAAEngine {
         } catch (CASException e) {
             e.printStackTrace();
         }
+    }
+
+    @Nonnull
+    protected JCas initializeIaaView(JCas jCas) {
+        JCas viewIAA = JCasUtil.getView(jCas, "IAA", true);
+        if (viewIAA.getDocumentText() == null)
+            viewIAA.setDocumentText(jCas.getDocumentText());
+        viewIAA.removeAllIncludingSubtypes(AgreementValue.type);
+        return viewIAA;
     }
 
     private void handleSeparate(


### PR DESCRIPTION
Fixed bugs in RelationAnnotationAgreement engine
- Fixed bug when choosing COMBINED or BOTH multi-CAS handling strategies for the RelationAnnotationAgreement engine.
- Fixed bug that prevents previous AgreementValue annotations to not be deleted upon re-running the RelationAnnotationAgreement engine.